### PR TITLE
trouble with /dev/null

### DIFF
--- a/lib/jekyll-browsersync/command.rb
+++ b/lib/jekyll-browsersync/command.rb
@@ -48,14 +48,7 @@ module Mlo
 
           ::Jekyll::Commands::Build.process(config)
 
-          PTY.spawn(cmd) do |stdout, stdin, pid|
-            trap("INT") { Process.kill "INT", pid }
-    
-            begin
-              stdout.each { |line| ::Jekyll.logger.info(line.rstrip) }
-            rescue
-            end
-          end
+          system(cmd)
         end
 
         private

--- a/lib/jekyll-browsersync/command.rb
+++ b/lib/jekyll-browsersync/command.rb
@@ -42,7 +42,7 @@ module Mlo
           args << "--no-open" unless config["open"]
           cmd = "#{cli} start #{args.join(" ")}"
 
-          if `#{cli} --version 2>/dev/null`.empty?
+          if `#{cli} --version`.empty?
             raise "Unable to locate browser-sync binary."
           end
 


### PR DESCRIPTION
For some reason outputing to /dev/null don't capture the version.
Tested in Windows 10 with Cygwin and PowerShell

```bash
$ bundle exec jekyll browsersync
Configuration file: E:/Project/_config.yml
O sistema não pode encontrar o caminho especificado.
jekyll 4.0.0 | Error:  Unable to locate browser-sync binary.
```

Removing the /dev/null output solved the problem.